### PR TITLE
Paraphrasing with QuillBot + Test done (headless=False)

### DIFF
--- a/lambdas/paraphrase_article/quillbot.py
+++ b/lambdas/paraphrase_article/quillbot.py
@@ -1,0 +1,202 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.options import Options
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
+
+import time
+
+from chromedriver_py import binary_path # this will get you the path variable
+
+def truncate(text, n):
+    words = text.split()
+    if len(words) <= n:
+        return text
+    truncated = ' '.join(words[:n])
+    return truncated[:truncated.rfind('.')] + '.'
+
+
+def get_input_selector(driver):
+    # Pause pour que la page se charge
+    time.sleep(1)
+
+    placeholder_text = 'To rewrite text, enter or paste it here and press "Paraphrase."'
+    input_selectors = [
+        '#inputText',
+        '#paraphraser-input-box',
+        f'div[placeholder="{placeholder_text}"]'
+    ]
+
+    for selector in input_selectors:
+        try:
+            WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, selector))
+            )
+            print(f'Success: Found element with selector {selector}')
+            return selector
+        except TimeoutException:
+            print(f'Selector {selector} not found.')
+            continue
+        except Exception as e:
+            print(f'Error finding selector {selector}: {e}')
+            continue
+
+    print('Error: Unable to find a valid input selector.')
+    # Optionally save page source and screenshot for debugging
+    with open('page_source.html', 'w') as file:
+        file.write(driver.page_source)
+    driver.save_screenshot('debug_screenshot.png')
+    return None
+
+def get_input_field(driver, input_selector):
+    try:
+        input_field = WebDriverWait(driver, 5).until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, input_selector))
+        )
+        return input_field
+    except:
+        print(f'Error: Unable to find the input field with the selector: {input_selector}')
+        return None
+
+def clear_input_field(driver, input_selector):
+    input_field = driver.find_element(By.CSS_SELECTOR, input_selector)
+    input_field.clear()
+
+    input_field.send_keys(Keys.CONTROL, 'a')
+    input_field.send_keys(Keys.BACKSPACE)
+
+def input_string(driver, input_selector, text):
+    input_field = driver.find_element(By.CSS_SELECTOR, input_selector)
+    input_field.send_keys(text)
+
+def get_button_selector(driver):
+    button_selectors = [
+        'button.quillArticleBtn',
+        '[aria-label="Rephrase (Cmd + Return)"] button',
+        '[aria-label="Paraphrase (Cmd + Return)"] button',
+        "//div[contains(text(), 'Paraphrase') or contains(text(), 'Rephrase')]/ancestor::button"
+    ]
+    for selector in button_selectors:
+        try:
+            if selector.startswith("//"):
+                button = driver.find_element(By.XPATH, selector)
+            else:
+                button = driver.find_element(By.CSS_SELECTOR, selector)
+            return selector
+        except:
+            continue
+    print('Error: Unable to find a valid button selector.')
+    return None
+
+def click_paraphrase_button(driver, button_selector):
+    try:
+        if button_selector.startswith("//"):
+            button = driver.find_element(By.XPATH, button_selector)
+        else:
+            button = driver.find_element(By.CSS_SELECTOR, button_selector)
+        button.click()
+        return True
+    except:
+        return False
+
+def wait_for_form_submission(driver, button_selector):
+    try:
+        WebDriverWait(driver, 10).until(
+            EC.invisibility_of_element_located((By.CSS_SELECTOR, f'{button_selector} div:nth-child(2)'))
+        )
+        return True
+    except:
+        print('Error: Process did not complete in the expected time.')
+        return False
+
+def get_output_content(driver, output_selector):
+    try:
+        content = driver.find_element(By.CSS_SELECTOR, output_selector).text
+        if not content:
+            print('Output element not found or no content.')
+            return None
+        return content
+    except Exception as e:
+        print(f'Error retrieving output content: {e}')
+        return None
+
+def quillbot(text, options=None):
+    if options is None:
+        options = {}
+
+    number_of_characters = 125
+    parts = []
+    output = ''
+    
+    if len(text.split()) > number_of_characters:
+        while len(text.split()) > number_of_characters:
+            part = truncate(text, number_of_characters)
+            text = text[len(part):].strip()
+            parts.append(part)
+        parts.append(text)
+    else:
+        parts.append(text)
+
+
+    chrome_options = Options()
+    headless = options['headless']
+    if headless:
+        chrome_options.add_argument("--headless")
+        chrome_options.add_argument("--disable-gpu")  # Optional: for GPU acceleration issues
+    chrome_options.add_argument("--no-sandbox")  # Optional: for sandbox issues
+    chrome_options.add_argument("--disable-dev-shm-usage")  # Optional: to deal with memory issues
+
+    # Specify the path to your chromedriver if necessary
+    service = Service(executable_path=binary_path)
+
+    driver = webdriver.Chrome(service=service, options=chrome_options)
+
+
+    #driver = webdriver.Chrome()
+    driver.get('https://quillbot.com/paraphrasing-tool')
+
+    try:
+        input_selector = get_input_selector(driver)
+        input_field = get_input_field(driver, input_selector)
+
+        if not input_field:
+            print('Input field not found. Exiting script.')
+            return
+
+        for i, part in enumerate(parts):
+            print(f'Paraphrasing part {i + 1} of {len(parts)}')
+
+            time.sleep(1)
+            clear_input_field(driver, input_selector)
+            time.sleep(1)
+            input_string(driver, input_selector, part)
+            time.sleep(1)
+
+            button_selector = get_button_selector(driver)
+            if not click_paraphrase_button(driver, button_selector):
+                print('Form submission failed. Exiting script.')
+                return
+
+            if not wait_for_form_submission(driver, button_selector):
+                print('Form submission failed. Exiting script.')
+                return
+
+            output_content = get_output_content(driver, '#paraphraser-output-box')
+            if output_content:
+                output += output_content
+            else:
+                print('Output content not found. Exiting script.')
+                return
+
+            print(f'Paraphrasing complete {i + 1} of {len(parts)}')
+            time.sleep(1)
+
+        print('Paraphrasing complete')
+        return output
+
+    finally:
+        driver.quit()

--- a/lambdas/paraphrase_article/requirements.txt
+++ b/lambdas/paraphrase_article/requirements.txt
@@ -1,2 +1,4 @@
 boto3
 requests
+selenium
+chromedriver-py

--- a/lambdas/paraphrase_article/test_paraphraser.py
+++ b/lambdas/paraphrase_article/test_paraphraser.py
@@ -1,0 +1,34 @@
+from quillbot import quillbot
+
+def main():
+    paragraph = (
+        '''Different free writing compositions are used to inform various target audiences.
+        They can be find in almost any source, which includes print media and online sources. 
+        With the advancement of modern technology, such sources have become more easier to access by the day.
+        The word article can be used to refer to a brief written composition which is often found
+        among other compositions typically included in different publications (e.g. newspaper, magazines, online, etc).
+        An article can tackle about different topics, depending on the writer, and is usually intended for a target audience.
+        Article writing example is the process of writing an article for a specific purpose and audience. 
+        Articles are written to discuss different subjects or topics. Articles included in publications usually 
+        contain information on current issues or events happening around the area of the writer or the publication.
+        Writers present information in various ways, such as in an informative, or argumentative form. Basis of information 
+        written on articles may vary. Such facts may be gathered from different sources, such as eyewitness accounts, 
+        one on one interviews, and online, among others.'''
+    )
+
+    options = {
+        'headless': False,  # default will be True -> TODO
+        'language': 'English (AU)',  # default 'English (UK)'
+        'mode': 'Fluency',  # default 'Standard'
+        'synonymsLevel': 0  # default is 50, can be set from 0 to 100
+    }
+
+    paraphrased = quillbot(paragraph, options)
+
+    print('Before:')
+    print(paragraph)
+    print('\n\nParaphrased:')
+    print(paraphrased)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Paraphrasing with QuillBot is currently set with headless=False.

TODO:

- Bypass Cloudflare checks when headless=True.
- Implement functions to configure QuillBot parameters: (language, mode, synonymsLevel).